### PR TITLE
[Do not merge] Fix warnings related to issue #17 (and make a test fail...)

### DIFF
--- a/include/strf/detail/facets/numpunct.hpp
+++ b/include/strf/detail/facets/numpunct.hpp
@@ -438,11 +438,22 @@ template <int Base> struct numpunct_c
 
     constexpr static int base = Base;
 
-    static const strf::default_numpunct<base>& get_default()
+    static STRF_HD const strf::default_numpunct<base>& get_default()
     {
+#ifdef __CUDA_ARCH__
+        asm("trap;");
+            // TODO: Think of a better solution for having a single instance to use here.
+            // We would need some mechanism for global initialization (e.g. perhaps
+            // based on compare-and
+#else
         static const strf::default_numpunct<base> x{};
         return x;
+#endif
+#pragma push
+#pragma diag_suppress = implicit_return_from_non_void_function
     }
+#pragma diag_default = implicit_return_from_non_void_function
+#pragma pop
 };
 
 namespace detail {

--- a/include/strf/detail/format_functions.hpp
+++ b/include/strf/detail/format_functions.hpp
@@ -45,14 +45,14 @@ template <typename FmtA, typename FmtB, typename ValueWithFormat>
 struct fmt_forward_switcher
 {
     template <typename FmtAInit>
-    static const typename FmtB::template fn<ValueWithFormat>&
+    static STRF_HD const typename FmtB::template fn<ValueWithFormat>&
     f(const FmtAInit&, const ValueWithFormat& v)
     {
         return v;
     }
 
     template <typename FmtAInit>
-    static typename FmtB::template fn<ValueWithFormat>&&
+    static STRF_HD typename FmtB::template fn<ValueWithFormat>&&
     f(const FmtAInit&, ValueWithFormat&& v)
     {
         return v;

--- a/include/strf/detail/tr_string.hpp
+++ b/include/strf/detail/tr_string.hpp
@@ -50,7 +50,7 @@ struct tr_invalid_arg_c
 {
     static constexpr bool constrainable = false;
 
-    static constexpr tr_invalid_arg get_default() noexcept
+    static constexpr STRF_HD tr_invalid_arg get_default() noexcept
     {
         return tr_invalid_arg::replace;
     }

--- a/test/facets_pack.cpp
+++ b/test/facets_pack.cpp
@@ -124,7 +124,7 @@ template <int N> struct fcategory
 {
     constexpr static bool constrainable = true;
 
-    constexpr static facet<N> get_default() noexcept
+    constexpr static STRF_HD facet<N> get_default() noexcept
     {
         return facet<N>{-1};
     }

--- a/test/facets_pack_merge.cpp
+++ b/test/facets_pack_merge.cpp
@@ -17,7 +17,7 @@ struct facet_type
 struct fcategory
 {
     constexpr static bool constrainable = true;
-    static auto get_default() noexcept
+    static STRF_HD auto get_default() noexcept
     {
         return facet_type {};
     }

--- a/test/write_within_kernel.cu
+++ b/test/write_within_kernel.cu
@@ -32,6 +32,10 @@ __global__ void kernel_using_cstr_to(char* buffer, std::size_t buffer_size)
 	int global_thread_id = threadIdx.x + blockIdx.x * blockDim.x;
 	auto printer = strf::to(buffer, buffer_size);
 	printer ( "Hello", ' ', "world, from thread ", global_thread_id );
+	auto formatted = strf::fmt(123);
+	printer ( formatted );
+//	auto width = 10;
+//	printer ( "My thread number again, with width ", width, " is ", (strf::fmt(global_thread_id) > 10) );
 }
 
 


### PR DESCRIPTION
* Made some host-only functions into `STRF_HD` (host-and-device) - especially `get_default()` and `fn()` methods
* Added an `fmt()` result printing to the `kernel_using_cstr_to` kernel of the `write_within_kernel` testcase.

The `write_within_kernel` testcase fails with `fmt()` getting called.