### PR TITLE
docs: fix minor typos and grammar

### DIFF
--- a/docs/quick_reference.adoc
+++ b/docs/quick_reference.adoc
@@ -1018,7 +1018,7 @@ assert(result == "*15.00 \xE2\x82\xAC \x80"); // width calculated as 11
   Nonconformities do not cause undefined behaviour, but lead to incorrect
   values. For example, the width of an UTF-8 string may simply be calculated as
   the number of bytes that are not in the range [`0x80`, `0xBF`], __i.e.__,
-  btye that are not continuation bytes. This way, any extra continuation byte -- that
+  byte that are not continuation bytes. This way, any extra continuation byte -- that
   would replaced by a `"\uFFFD"` during sanitization -- is not counted.
 +
 .Example

--- a/docs/quick_reference.adoc
+++ b/docs/quick_reference.adoc
@@ -660,7 +660,7 @@ assert(str == "Paul likes sandwich.");
 [[tr_string_error]]
 === Tr-string error handling
 
-When the argument associated with a `"{"` does not exists, the library does two things:
+When the argument associated with a `"{"` does not exist, the library does two things:
 
 - It prints a https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character[replacement character `"\uFFFD"` (&#65533;) ] ( or `"?"` when the charset can't represent it ) where the missing argument would be printed.
 - It calls the `handle` function on the facet object correspoding to the `<<strf_hpp#tr_error_notifier_c,tr_error_notifier_c>>` category, which, by default, does nothing.

--- a/docs/quick_reference.adoc
+++ b/docs/quick_reference.adoc
@@ -852,7 +852,7 @@ assert(s == "one hundred billions = 1\2250000\225000\2250000");
 [[charset_conversion]]
 === Charset conversion
 
-Since the library knows the encoding correspondig to each
+Since the library knows the encoding corresponding to each
 character type, and knows how to convert from one to another,
 it is possible to mix input string of difference characters
 types, though you need to use the function `conv`:

--- a/docs/quick_reference.adoc
+++ b/docs/quick_reference.adoc
@@ -919,7 +919,7 @@ NOTE: The library does not sanitizes non-conformities when converting a single c
 like punctuation characters or the the fill character ( they are in UTF-32 ). In this case
 the replacement character is only used when the destination charset is not able
 to print the codepoint.
-For example, if the you use `(char32_t)0xFFFFFFF` as the <<numpunct,decimal point>>,
+For example, if you use `(char32_t)0xFFFFFFF` as the <<numpunct,decimal point>>,
 then it will printed as "\uFFFD" if the destination is UTF-8 or UTF-16, but
 if the destination is UTF-32, then the library just writes `(char32_t)0xFFFFFFF`
 verbatim.

--- a/docs/quick_reference.adoc
+++ b/docs/quick_reference.adoc
@@ -5,7 +5,7 @@ Distributed under the Boost Software License, Version 1.0.
 http://www.boost.org/LICENSE_1_0.txt)
 ////
 
-= The Strf formatting library - Quit Reference
+= The Strf formatting library - Quick Reference
 :source-highlighter: prettify
 :sectnums:
 :sectnumlevels: 0

--- a/docs/ref_facets_pack.adoc
+++ b/docs/ref_facets_pack.adoc
@@ -110,7 +110,7 @@ Compile-time requirements::  `FCat` is a _{FacetCategory}_ type.
 
 [[has_facet]]
 === Hypothetical function template `has_facet`
-NOTE: This function template does not exists in this library.
+NOTE: This function template does not exist in this library.
        It is only documented to help to explain the
        <<use_facet, `use_facet`>> function template.
 ====

--- a/docs/ref_facets_pack.adoc
+++ b/docs/ref_facets_pack.adoc
@@ -65,7 +65,7 @@ Compile-time requirements:: `(std::is_default_constructible_v<FPE> && \...)` is 
 template <typename... U>
 constexpr explicit facets_pack(U&&... u)
 ----
-Effects:: Initializes each element with the correspondig value in `std::forward<U>(u)\...`.
+Effects:: Initializes each element with the corresponding value in `std::forward<U>(u)\...`.
 Compile-time requirements:: This constructor does not participate in overload resolution, unless the following conditions are met
 - `sizeof\...(U) != 0` is `true`
 - `sizeof\...(U) == sizeof\...(FPE)` is `true`

--- a/docs/ref_format_functions.adoc
+++ b/docs/ref_format_functions.adoc
@@ -394,7 +394,7 @@ The _Formatter_ defines the following format functions:
 | Format functions | Effect
 
 |`operator<({width_t} _width_)`
-| Aligns to the left ( Or to the right on right-to-left (RTL) scripts, like arabic )
+| Aligns to the left ( Or to the right on right-to-left (RTL) scripts, like Arabic )
 
 |`operator>({width_t} _width_)`
 | Aligns to the right ( Or to the left on RTL scripts )

--- a/docs/ref_tr-string.adoc
+++ b/docs/ref_tr-string.adoc
@@ -56,7 +56,7 @@ assert(str == "} {x} {aaa {bbb}");
 
 ==== Syntax error handling
 
-When the argument associated with a `"{"` does not exists, the library does two things:
+When the argument associated with a `"{"` does not exist, the library does two things:
 
 - It prints a https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character[replacement character `"\uFFFD"` (&#65533;) ]
  ( or `"?"` when the charset can't represent it ) where the missing argument would be printed.

--- a/docs/tutorial.adoc
+++ b/docs/tutorial.adoc
@@ -68,7 +68,7 @@ the <<quick_reference#tr_string,tr-string>>:
 auto s = strf::to_string.tr("{} in hexadecimal is {}", x, strf::hex(x));
 ----
 
-The `reserve`, `no_reseve` and `reserve_calc` functions are only available for some
+The `reserve`, `no_reserve` and `reserve_calc` functions are only available for some
 __dest-expr__s, `to_string` being one of them.
 Using `reserve(size)` causes the destination to reserve enough space
 to store `size` characters. `reserve_calc()` has the same effect,

--- a/tests/string_writer.cpp
+++ b/tests/string_writer.cpp
@@ -199,7 +199,7 @@ static void test_sized_string_maker()
         auto str = dest.finish();
         TEST_TRUE(str == str0 + half_str);
     }
-    {   // test strf::to_basic_string.reseve(...)
+    {   // test strf::to_basic_string.reserve(...)
 #if defined(STRF_HAS_VARIABLE_TEMPLATES)
 
         auto str = strf::to_basic_string<CharT>.reserve(1000)(tiny_str, tiny_str2);


### PR DESCRIPTION
Minor documentation fixes. No code changes.